### PR TITLE
fix(router): it removes default redirection for guards

### DIFF
--- a/src/lib/router/core/router.ts
+++ b/src/lib/router/core/router.ts
@@ -80,7 +80,6 @@ export class Router implements IRouter {
         this.activeRouteSnapshot,
         this.handlersFacade,
         this.routeGuard,
-        this.historyAdapter,
         new RouteNavigationApi(this.historyAdapter),
       );
       await matcher.matchRoute(this.routes, this.element);

--- a/src/lib/router/types.ts
+++ b/src/lib/router/types.ts
@@ -1,10 +1,10 @@
 import { HistoryAPIAdapter } from '@/lib/router/core/adapters/history.adapter.ts';
 import { HandlersFacade } from '@/lib/router/core/handlers/handlers.facade.ts';
 
-export type CanActivateFn = (route?: Route) => boolean;
+export type CanActivateFn = (route?: Route) => boolean | Promise<boolean>;
 
 export interface IRouteGuard {
-  handleCanActivate: (route: Route) => boolean;
+  handleCanActivate: (route: Route) => boolean | Promise<boolean>;
 }
 
 export type Route = {

--- a/test/router/core/guards/guards.test.ts
+++ b/test/router/core/guards/guards.test.ts
@@ -5,7 +5,11 @@ import { CanActivateFn, HandlersFacade, router } from '@/lib/router';
 import { Component, html } from '@/lib/dom';
 import { waitForRouting } from '@/lib/utils';
 
-const authGuard: CanActivateFn = () => false;
+const authGuard: CanActivateFn = () => {
+  const route = router();
+  route.navigateByUrl('/home');
+  return false;
+};
 
 const authAdminGuard: CanActivateFn = () => true;
 


### PR DESCRIPTION
This commit replaces default redirection made inside router in favor of using router.navigateByUrl from Router API, this way it's possible to redirect to wherever needed

closes #3